### PR TITLE
Fix cloudflare build errors

### DIFF
--- a/src/routes/gallery/components/PhotoGrid.svelte
+++ b/src/routes/gallery/components/PhotoGrid.svelte
@@ -61,14 +61,7 @@
 <div class="columns-1 sm:columns-2 lg:columns-3 xl:columns-4 2xl:columns-5 gap-6 space-y-6">
 	{#each photos as photo (photo.id)}
 		<div 
-			class="group relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-3xl shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-3 hover:scale-105 cursor-pointer overflow-hidden break-inside-avoid mb-6 border-2 hover-lift"
-			class:border-white/20={!batchMode && !selectedPhotos.has(photo.id)}
-			class:dark:border-gray-700/50={!batchMode && !selectedPhotos.has(photo.id)}
-			class:border-purple-500={batchMode && selectedPhotos.has(photo.id)}
-			class:bg-purple-50={batchMode && selectedPhotos.has(photo.id)}
-			class:dark:bg-purple-900/30={batchMode && selectedPhotos.has(photo.id)}
-			class:border-gray-300={batchMode && !selectedPhotos.has(photo.id)}
-			class:dark:border-gray-600={batchMode && !selectedPhotos.has(photo.id)}
+			class="group relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-sm rounded-3xl shadow-lg hover:shadow-2xl transition-all duration-500 transform hover:-translate-y-3 hover:scale-105 cursor-pointer overflow-hidden break-inside-avoid mb-6 border-2 hover-lift {!batchMode && !selectedPhotos.has(photo.id) ? 'border-white/20 dark:border-gray-700/50' : ''} {batchMode && selectedPhotos.has(photo.id) ? 'border-purple-500 bg-purple-50 dark:bg-purple-900/30' : ''} {batchMode && !selectedPhotos.has(photo.id) ? 'border-gray-300 dark:border-gray-600' : ''}"
 			on:click={() => handlePhotoClick(photo)}
 			role="button"
 			tabindex="0"
@@ -131,7 +124,7 @@
 							<!-- Edit Button -->
 							<button
 								class="p-2 bg-white/20 backdrop-blur-sm rounded-full text-white transition-all duration-300 hover:bg-purple-500/70 hover:scale-110"
-								on:click={(e) => { e.stopPropagation(); handlePhotoClick(photo); }}"
+								on:click={(e) => { e.stopPropagation(); handlePhotoClick(photo); }}
 								title="Edit photo"
 							>
 								<svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">

--- a/src/routes/gallery/components/PhotoModal.svelte
+++ b/src/routes/gallery/components/PhotoModal.svelte
@@ -208,6 +208,7 @@
 					on:click={downloadPhoto}
 					class="p-3 bg-black/20 backdrop-blur-sm rounded-full text-white hover:bg-black/40 transition-all duration-300 hover:scale-110"
 					title="Download photo"
+					aria-label="Download photo"
 				>
 					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 10v6m0 0l-3-3m3 3l3-3m2 8H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path>
@@ -217,6 +218,7 @@
 					on:click={sharePhoto}
 					class="p-3 bg-black/20 backdrop-blur-sm rounded-full text-white hover:bg-black/40 transition-all duration-300 hover:scale-110"
 					title="Share photo"
+					aria-label="Share photo"
 				>
 					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M8.684 13.342C8.886 12.938 9 12.482 9 12c0-.482-.114-.938-.316-1.342m0 2.684a3 3 0 110-2.684m0 2.684l6.632 3.316m-6.632-6l6.632-3.316m0 0a3 3 0 105.367-2.684 3 3 0 00-5.367 2.684zm0 9.316a3 3 0 105.367 2.684 3 3 0 00-5.367-2.684z"></path>
@@ -226,6 +228,7 @@
 					on:click={openPhotoEditor}
 					class="p-3 bg-black/20 backdrop-blur-sm rounded-full text-white hover:bg-black/40 transition-all duration-300 hover:scale-110"
 					title="Edit photo"
+					aria-label="Edit photo"
 				>
 					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 20h9M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"></path>
@@ -235,6 +238,7 @@
 					on:click={openFrameEditor}
 					class="p-3 bg-black/20 backdrop-blur-sm rounded-full text-white hover:bg-black/40 transition-all duration-300 hover:scale-110"
 					title="Add frame"
+					aria-label="Add frame"
 				>
 					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"></path>
@@ -244,6 +248,7 @@
 					on:click={handleEdit}
 					class="p-3 bg-black/20 backdrop-blur-sm rounded-full text-white hover:bg-black/40 transition-all duration-300 hover:scale-110"
 					title="Edit photo"
+					aria-label="Edit photo"
 				>
 					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M11 5H6a2 2 0 00-2 2v11a2 2 0 002 2h11a2 2 0 002-2v-5m-1.414-9.414a2 2 0 112.828 2.828L11.828 15H9v-2.828l8.586-8.586z"></path>
@@ -253,6 +258,7 @@
 					on:click={handleDelete}
 					class="p-3 bg-black/20 backdrop-blur-sm rounded-full text-white hover:bg-red-500 transition-all duration-300 hover:scale-110"
 					title="Delete photo"
+					aria-label="Delete photo"
 				>
 					<svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
 						<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>


### PR DESCRIPTION
Fix Cloudflare build failure by resolving a syntax error in `PhotoGrid.svelte` and improving button accessibility in `PhotoModal.svelte`.

The build was failing due to an "Expected token >" syntax error in `PhotoGrid.svelte`, caused by a stray quote in an `on:click` handler and a very long `class` attribute that was causing parsing issues. Additionally, Svelte accessibility warnings for buttons missing explicit labels in `PhotoModal.svelte` were addressed.

---
<a href="https://cursor.com/background-agent?bcId=bc-fcf20ec0-392d-4a59-8122-e9192a12e769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fcf20ec0-392d-4a59-8122-e9192a12e769">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

