### PR TITLE
Fix svelte build errors

### DIFF
--- a/src/routes/brainstorm/components/FeatureCard.svelte
+++ b/src/routes/brainstorm/components/FeatureCard.svelte
@@ -79,8 +79,8 @@
 				</div>
 			</div>
 			<div class="dropdown dropdown-end">
-				<label tabindex="0" class="btn btn-ghost btn-xs">⋮</label>
-				<ul tabindex="0" class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
+				<div role="button" class="btn btn-ghost btn-xs">⋮</div>
+				<ul class="dropdown-content z-[1] menu p-2 shadow bg-base-100 rounded-box w-52">
 					<li><button onclick={() => showDetails = !showDetails}>
 						{showDetails ? 'Hide' : 'Show'} Details
 					</button></li>

--- a/src/routes/brainstorm/components/FeatureForm.svelte
+++ b/src/routes/brainstorm/components/FeatureForm.svelte
@@ -72,7 +72,7 @@
 	}
 </script>
 
-<form onsubmit|preventDefault={handleSubmit} class="space-y-4">
+<form on:submit|preventDefault={handleSubmit} class="space-y-4">
 	<!-- Title -->
 	<div class="form-control">
 		<label class="label" for="title">

--- a/src/routes/store/[shopID]/+page.svelte
+++ b/src/routes/store/[shopID]/+page.svelte
@@ -716,27 +716,27 @@
                 <!-- Price -->
                 {#if pricingOption === 'price_only'}
                 <div class="form-control mb-4">
-                    <label class="label">
+                    <label class="label" for="price-input">
                         <span class="label-text">ราคา</span>
                     </label>
-                    <input type="number" name="price" bind:value={editingItem.price} class="input input-bordered" required />
+                    <input id="price-input" type="number" name="price" bind:value={editingItem.price} class="input input-bordered" required />
                 </div>
                 {/if}
 
                 <!-- Price Pri and Price Test -->
                 {#if pricingOption === 'price_pri_test'}
                 <div class="form-control mb-4">
-                    <label class="label">
+                    <label class="label" for="price-pri-input">
                         <span class="label-text">ราคาไพร</span>
                     </label>
-                    <input type="number" name="price_pri" bind:value={editingItem.price_pri} class="input input-bordered" required />
+                    <input id="price-pri-input" type="number" name="price_pri" bind:value={editingItem.price_pri} class="input input-bordered" required />
                 </div>
 
                 <div class="form-control mb-4">
-                    <label class="label">
+                    <label class="label" for="price-test-input">
                         <span class="label-text">ราคาเทส</span>
                     </label>
-                    <input type="number" name="price_test" bind:value={editingItem.price_test} class="input input-bordered" required />
+                    <input id="price-test-input" type="number" name="price_test" bind:value={editingItem.price_test} class="input input-bordered" required />
                 </div>
                 {/if}
 


### PR DESCRIPTION
Fix Cloudflare build failures by correcting Svelte syntax and resolving accessibility issues.

The build was failing due to an invalid Svelte event modifier syntax (`onsubmit|preventDefault`) and several accessibility warnings related to unassociated form labels and incorrect `tabindex` usage on non-interactive elements, which were treated as errors by the build process.

---
<a href="https://cursor.com/background-agent?bcId=bc-6ae7e2bd-e3ef-4c41-a872-b5fd63260295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-6ae7e2bd-e3ef-4c41-a872-b5fd63260295">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

