### PR TITLE
Fix module resolution error during build

### DIFF
--- a/src/routes/store/[shopID]/[outfitID]/+page.svelte
+++ b/src/routes/store/[shopID]/[outfitID]/+page.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
 	import { page } from '$app/stores';
-	import ImageManager from '../../components/ImageManager.svelte';
+	import ImageManager from '../../../components/ImageManager.svelte';
 	import type { StorePageData, ItemData, ShopData, ImageCheckResponse } from '../../../types/images';
 	
 


### PR DESCRIPTION
Fix incorrect import path for `ImageManager.svelte` to resolve build failure.

---
<a href="https://cursor.com/background-agent?bcId=bc-fd0bcd7a-a8cd-42bf-b741-4ba64c7daeda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fd0bcd7a-a8cd-42bf-b741-4ba64c7daeda">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

